### PR TITLE
Shutup and un-shutup users

### DIFF
--- a/app.js
+++ b/app.js
@@ -4,6 +4,7 @@ const config = require('./config/config.json');
 const lang = require('./config/lang.json');
 const commands = require('./services/commandService.js').commands;
 const utils = require('./utils/botutils.js');
+const userUtils = require('./utils/userUtils.js');
 const client = new Discord.Client();
 const request = require('request');
 
@@ -59,6 +60,10 @@ client.on('ready', () => {
 
 client.on('message', msg => {
     if (!acceptMessages || msg.author.bot || !canReply(msg)) {
+        return;
+    }
+    if (userUtils.userMuted(msg.author.id)) {
+        msg.delete(0); // Delete message if user is muted
         return;
     }
     if(!utils.validateMsg(msg.content)){

--- a/config/lang.json
+++ b/config/lang.json
@@ -62,6 +62,30 @@
       "ignore": false,
       "permissions": ["all"]
     },
+    "shutup": {
+      "name": "shutup",
+      "args": [
+        "person", "durationSeconds"
+      ],
+      "description": "Shut <person> up for <durationSeconds> seconds.",
+      "shortcuts": [
+        "shutup", "mute"
+      ],
+      "ignore": false,
+      "permissions": ["admin"]
+    },
+    "unmute": {
+      "name": "unmute",
+      "args": [
+        "person"
+      ],
+      "description": "Unmute (un-shutup) <person>",
+      "shortcuts": [
+        "unshutup", "unmute"
+      ],
+      "ignore": false,
+      "permissions": ["admin"]
+    },
     "joke": {
       "name": "joke",
       "args": [],

--- a/config/lang.json
+++ b/config/lang.json
@@ -65,9 +65,9 @@
     "shutup": {
       "name": "shutup",
       "args": [
-        "person", "durationSeconds"
+        "person", "durationMinutes"
       ],
-      "description": "Shut <person> up for <durationSeconds> seconds.",
+      "description": "Shut <person> up for <durationMinutes> minutes.",
       "shortcuts": [
         "shutup", "mute"
       ],

--- a/services/commandService.js
+++ b/services/commandService.js
@@ -105,7 +105,7 @@ const commandService = {
             return;
         }
         var userToMute = msg.mentions.members.first();
-        msg.channel.send("Sorry, <@${userToMute.username}>, you have been shut up for ${args[1]} minutes. You will find that your messages will evaporate upon being sent.");
+        msg.channel.send(`Sorry, <@${userToMute.username}>, you have been shut up for ${args[1]} minutes. You will find that your messages will evaporate upon being sent.`);
         
         userUtils.shutupUser(userToMute.id, args[1]);
     },
@@ -123,7 +123,7 @@ const commandService = {
             return;
         }
         var userToUnmute = msg.mentions.members.first();
-        msg.channel.send("<@${userToMute.username}>, you have been unmuted. Enjoy some freedom!");
+        msg.channel.send(`<@${userToMute.username}>, you have been unmuted.`);
         
         userUtils.unmuteUser(userToUnmute.id);
     },

--- a/services/commandService.js
+++ b/services/commandService.js
@@ -2,6 +2,7 @@ const request = require('request');
 const config = require('../config/config');
 const cheerio = require('cheerio');
 const utils = require('../utils/botutils');
+const userUtils = require('../utils/userUtils');
 const lang = require('../config/lang.json');
 const DataSystem = require('../utils/fileUtils');
 
@@ -89,6 +90,42 @@ const commandService = {
             await msg.guild.members.get(person.id).setNickname(old_nicname);
         },300000);
 
+    },
+    shutup: (msg, args, client, sudo) => {
+        if (!sudo) {
+            msg.channel.send("No. Not without sudo.")
+            return;
+        }
+        if (args.length < 2) {
+            msg.channel.send("You idiot. Ya don't even know how to use the command properly.");
+            return;
+        }
+        if(Math.random() > 0.1){
+            msg.channel.send("Will I listen to you :thinking: ? No... I don't think I will.... :smiling_imp:");
+            return;
+        }
+        var userToMute = msg.mentions.members.first();
+        msg.channel.send("Sorry, <@${userToMute.username}>, you have been shut up for ${args[1]} minutes. You will find that your messages will evaporate upon being sent.");
+        
+        userUtils.shutupUser(userToMute.id, args[1]);
+    },
+    unmute: (msg, args, client, sudo) => {
+        if (!sudo) {
+            msg.channel.send("I refuse, unless you use sudo.")
+            return;
+        }
+        if (args.length < 1) {
+            msg.channel.send("You idiot. Ya gotta tell me _who_ to unmute. duh!");
+            return;
+        }
+        if(Math.random() > 0.1){
+            msg.channel.send("Will I listen to you :thinking: ? No... I don't think I will.... :smiling_imp:");
+            return;
+        }
+        var userToUnmute = msg.mentions.members.first();
+        msg.channel.send("<@${userToMute.username}>, you have been unmuted. Enjoy some freedom!");
+        
+        userUtils.unmuteUser(userToUnmute.id);
     },
     joke: (msg, args, client, sudo) => {
         if (Math.random() <= 0.1 && args !== "bypass") {

--- a/utils/userUtils.js
+++ b/utils/userUtils.js
@@ -11,11 +11,11 @@ function unmuteUser(userId) {
     }
 }
 
-function shutupUser(userId, durationSeconds) {
+function shutupUser(userId, durationMinutes) {
     // Remove all previous instances of same user from array:
     unmuteUser(userId);
     // Push userId, and mute end time to arrayy:
-    mutedUsers.push([userId, Date.now() + durationSeconds*1000]);
+    mutedUsers.push([userId, Date.now() + parseInt(durationMinutes)*1000*60]);
 }
 
 function userMuted(userId) {

--- a/utils/userUtils.js
+++ b/utils/userUtils.js
@@ -1,0 +1,33 @@
+
+
+var mutedUsers = []; // This will have to persist across restarts in the future. We can fix it once the save system is working.
+
+function unmuteUser(userId) {
+    while (true) {
+        user = mutedUsers.find((currVal) => currVal[0] === userId);
+        if (!user) break;
+        userIndex = mutedUsers.indexOf(user);
+        mutedUsers.splice(userIndex, 1);
+    }
+}
+
+function shutupUser(userId, durationSeconds) {
+    // Remove all previous instances of same user from array:
+    unmuteUser(userId);
+    // Push userId, and mute end time to arrayy:
+    mutedUsers.push([userId, Date.now() + durationSeconds*1000]);
+}
+
+function userMuted(userId) {
+    user = mutedUsers.find((currVal) => currVal[0] === userId);
+    if (!user) return false;
+    if (user[1] >= Date.now()) {
+        userIndex = mutedUsers.indexOf(user);
+        mutedUsers.splice(userIndex, 1); // remove user from array if mute has expired.
+        return false;
+    }
+    
+    return true;
+}
+
+module.exports = {shutupUser, userMuted, unmuteUser}


### PR DESCRIPTION
`shutup <person> <minutes>` deletes all messages from \<person> for \<minutes> minutes.

`unmute <person>` removes all mutes on \<person> (if there are any).

I'm not completely sure this will work because I haven't set up a test discord server yet, but I've tested it enough to know that it shouldn't crash the bot, at least.

TODO: 
+ make mutes persist across restarts. (currently they are stored in a variable)
+ Ignore commands to shutup admin users?